### PR TITLE
Changes made to fetch credentials from secured location.

### DIFF
--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,0 +1,4 @@
+{
+    "RPA_SECRET_MANAGER": "RPA.Robocorp.Vault.FileSecrets",
+    "RPA_SECRET_FILE": "C:\\Users\\lenovo\\OneDrive\\Desktop\\Masters_CompSci\\vault.json"
+}

--- a/tasks.robot
+++ b/tasks.robot
@@ -5,6 +5,7 @@ Library             RPA.Browser.Selenium    auto_close=${False}
 Library             RPA.HTTP
 Library             RPA.Excel.Files
 Library             RPA.PDF
+Library             RPA.Robocorp.Vault
 
 
 *** Tasks ***
@@ -24,8 +25,9 @@ Open the intranet website
     Open Available Browser    https://robotsparebinindustries.com/    maximized=${True}
 
 Log in
-    Input Text    username    maria
-    Input Password    password    thoushallnotpass
+    ${secret}=    Get Secret    robotsparebin
+    Input Text    username    ${secret}[username]
+    Input Password    password    ${secret}[password]
     Submit Form
     Wait Until Page Contains Element    id:sales-form
 


### PR DESCRIPTION
This pull request removes the hard-coded login credentials from the robot to a vault for better security.

To test this, create a vault.json file in your home directory (/Users/<your-username>). Paste the following JSON and update the value for the username and the password properties:
`
{
  "robotsparebin": {
    "username": "username-here",
    "password": "password-here"
  }
}
`
